### PR TITLE
Add support for independent subrequests within the current request

### DIFF
--- a/lib/bgaluszka/Mbank/Mbank.php
+++ b/lib/bgaluszka/Mbank/Mbank.php
@@ -1058,6 +1058,40 @@ class Mbank
 	}
 
 	/**
+     * Allows executing a request from outside the class
+     * to run parallel or isolated requests
+     *
+     * @param array $opts optional array of cURL extension options to pass to its curl_exec()
+	 * @return array
+	 *
+	 * @throws \RuntimeException
+	 */
+    public function getCurl(array $opts = array())
+	{
+		return $this->curl($opts);
+	}
+
+	/**
+     * Returns the resolved base URL.
+     *
+     * @return string
+     */
+	public function getUrl()
+	{
+		return $this->url();
+	}
+
+    /**
+     * Returns the DOMXPath instance.
+     *
+     * @return \DOMXPath
+     */
+    public function getDOMXPath()
+    {
+        return $this->xpath();
+    }
+	
+	/**
 	 * @param string|array $html
 	 * @param bool         $add_xml_header if @true, we append <?xml encoding="UTF-8"> to data prior loading the data.
 	 *                                     Needed to ensure proper encoding of accented characters. Default to @false
@@ -1066,7 +1100,7 @@ class Mbank
 	 *
 	 * @throws \RuntimeException
 	 */
-	protected function load($html, $add_xml_header = false)
+	public function load($html, $add_xml_header = false)
 	{
 		if (is_array($html)) {
 			$html = implode('', $html);


### PR DESCRIPTION
Allow to make sub request in to current request to get transaction information


```php
...
...



if($operation['title'] == 'PP/PRZELEW SORBNET PRZYCHODZĄCY'){

    $additionalCallMbank = new \bgaluszka\Mbank\Mbank();
    $additionalCallMbank->login($module->accout('login'), $module->accout('password'), $dfp, $mbank8);

    $additionalCall = $additionalCallMbank->getCurl([
        CURLOPT_URL => $additionalCallMbank->getUrl . '/pl/Pfm/Transaction/Details?transactionId=' . $transactionId,
        CURLOPT_HTTPHEADER => ['X-Requested-With: XMLHttpRequest']
    ]);

    $nodes = $additionalCallMbank->getDOMXPath->query("//tr[normalize-space(th)='Nazwa nadawcy']/td");

    if ($nodes->length > 0) {
        $title2 = trim($nodes->item(0)->textContent);
        $operation['title2'] = $title2;
    }

    $nodes = $additionalCallMbank->getDOMXPath->query("//tr[normalize-space(th)='Adres nadawcy']/td");

    if ($nodes->length > 0) {
        $title = trim($nodes->item(0)->textContent);
        $operation['title'] = '</b>'.$operation['title'].'</b> - '.$title;
    }

}
